### PR TITLE
add option to hide coordinates from command output

### DIFF
--- a/src/main/java/de/jeff_media/InvUnload/CommandSearchitem.java
+++ b/src/main/java/de/jeff_media/InvUnload/CommandSearchitem.java
@@ -122,7 +122,9 @@ public class CommandSearchitem implements CommandExecutor {
             }
         }
 
-        summary.print(UnloadSummary.PrintRecipient.PLAYER, p);
+        if (main.canSeeCoordinates(p)) {
+            summary.print(UnloadSummary.PrintRecipient.PLAYER, p);
+        }
 
         if(affectedChests.size()==0) {
             p.sendMessage(String.format(main.messages.MSG_NOTHING_FOUND,mat.name()));

--- a/src/main/java/de/jeff_media/InvUnload/CommandUnload.java
+++ b/src/main/java/de/jeff_media/InvUnload/CommandUnload.java
@@ -145,7 +145,7 @@ public class CommandUnload implements CommandExecutor , TabCompleter {
 				}
 			}
 		}
-		if(main.getConfig().getBoolean("always-show-summary")) {
+		if(main.getConfig().getBoolean("always-show-summary") && main.canSeeCoordinates(p)) {
 			summary.print(PrintRecipient.PLAYER, p);
 		}
 		

--- a/src/main/java/de/jeff_media/InvUnload/CommandUnloadinfo.java
+++ b/src/main/java/de/jeff_media/InvUnload/CommandUnloadinfo.java
@@ -65,7 +65,7 @@ public class CommandUnloadinfo implements CommandExecutor {
 				if(laser.isStarted()) laser.stop();
 			}
 		}*/
-		if(main.visualizer.unloadSummaries.containsKey(p.getUniqueId())) {
+		if(main.visualizer.unloadSummaries.containsKey(p.getUniqueId()) && main.canSeeCoordinates(p)) {
 			UnloadSummary summary = main.visualizer.unloadSummaries.get(p.getUniqueId());
 			if(summary!=null) {
 				summary.print(PrintRecipient.PLAYER, p);

--- a/src/main/java/de/jeff_media/InvUnload/Main.java
+++ b/src/main/java/de/jeff_media/InvUnload/Main.java
@@ -6,6 +6,8 @@ import de.jeff_media.InvUnload.Hooks.*;
 import de.jeff_media.InvUnload.utils.EnchantmentUtils;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
+import org.bukkit.GameRule;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -30,7 +32,7 @@ public class Main extends JavaPlugin implements Listener {
 	int mcMinorVersion; // 14 for 1.14, 13 for 1.13, ...
 
 	@SuppressWarnings("FieldCanBeLocal")
-	private final int currentConfigVersion = 34;
+	private final int currentConfigVersion = 37;
 
 	public Messages messages;
 	protected BlockUtils blockUtils;
@@ -173,6 +175,7 @@ public class Main extends JavaPlugin implements Listener {
 		getConfig().addDefault("particle-count", 100);
 		
 		getConfig().addDefault("always-show-summary", true);
+		getConfig().addDefault("show-coordinates", "default");
 		
 		getConfig().addDefault("laser-animation", true);
 		getConfig().addDefault("laser-default-duration", 5);
@@ -282,6 +285,30 @@ public class Main extends JavaPlugin implements Listener {
 		for(Map.Entry<UUID,PlayerSetting> entry : playerSettings.entrySet()) {
 			entry.getValue().save(getPlayerFile(entry.getKey()),this);
 		}
+	}
+
+	/**
+	 * Determines if given command sender can see coordinates of the chests in command output.
+	 */
+	public boolean canSeeCoordinates(CommandSender commandSender) {
+		if (commandSender.hasPermission("invunload.coordinates")) {
+			return true;
+		}
+
+		// Get reducedDebugInfo gamerule value.
+		boolean reducedDebugInfo = false;
+		if (commandSender instanceof Player) {
+			reducedDebugInfo = ((Player) commandSender).getWorld().getGameRuleValue(GameRule.REDUCED_DEBUG_INFO);
+		}
+
+		// By default, use reducedDebugInfo gamerule to decide if coordinates should be displayed.
+		if (this.getConfig().getString("show-coordinates").equals("default")) {
+			return !reducedDebugInfo;
+		}
+
+		// If show-coordinates config value is not set to 'default'
+		// ignore the gamerule and use configured boolean value.
+		return this.getConfig().getBoolean("show-coordinates");
 	}
 
 }

--- a/src/main/java/de/jeff_media/InvUnload/Visualizer.java
+++ b/src/main/java/de/jeff_media/InvUnload/Visualizer.java
@@ -85,6 +85,9 @@ public class Visualizer {
 	}
 	
 	void printSummaryToPlayer(Player p) {
+		if (!main.canSeeCoordinates(p)) {
+			return;
+		}
 		UnloadSummary summary = unloadSummaries.get(p.getUniqueId());
 		if(summary==null) return;
 		summary.print(PrintRecipient.PLAYER, p);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -46,9 +46,10 @@
 #######   Permissions   #######
 ###############################
 
-# invunload.use:        Allows to use the commands /unload, /dump, /unloadinfo, /blacklist
-# invunload.reload:     Allows to reload the config using /unload reload
-# invunload.search:     Allows to use the command /searchitem
+# invunload.use:         Allows to use the commands /unload, /dump, /unloadinfo, /blacklist
+# invunload.reload:      Allows to reload the config using /unload reload
+# invunload.search:      Allows to use the command /searchitem
+# invunload.coordinates: Allows to always see coordinates even when they are disabled in configuration
 
 ###############################
 ####### General config  #######
@@ -112,6 +113,13 @@ sound-effect: ENTITY_PLAYER_LEVELUP
 # or /dump.
 # When set to false, the summary is only shown when using /unloadinfo (or /dumpinfo).
 always-show-summary: true
+
+# Determines if coordinates should be shown in the text summaries and the output of the /searchitem command.
+# Can be overridden for specific player/group by granting 'invunload.coordinates' permission.
+# When set to default coordinates will be shown/hidden based on the reducedDebugInfo gamerule value.
+# When set to true the gamerule will be ignored and coordinates will be shown.
+# When set to false the gamerule will be ignored and coordinates will be hidden.
+show-coordinates: default
 
 # When set to true, InvUnload will draw the laser beam everytime you /unload or /dump
 # When set to false, InvUnload only draws the laser beam on /unloadinfo and /search
@@ -499,4 +507,4 @@ message-cooldown: "&cPlease wait a moment before running the command again."
 debug: false
 
 # please do not change the following line manually!
-config-version: 35
+config-version: 37

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -57,3 +57,5 @@ permissions:
     description: Allows usage of the /searchitem command
   invunload.reload:
     description: Allows to reload the config using /unload reload
+  invunload.coordinates:
+    descrition: Allows to see coordinates even when they are disabled in configuration.


### PR DESCRIPTION
Adds `show-coordinates` option to the config that depending on configured value hides/shows coordinates in commands output.
Available configuration values:
- `default` - (default) coordinates will be hidden if reducedDebugInfo [gamerule](https://minecraft.fandom.com/wiki/Game_rule) is set to true,
- `true` - coordinates will always be shown,
- `false` - coordinates will always be hidden.

New permission `invunload.coordinates` is also added that allows to always show coordinates for a specific player/group even when the plugin is configured to not show coordinates.

Resolves second point from https://github.com/JEFF-Media-GbR/InvUnload/issues/58. The third point is also effectively resolved since when `show-coordinates` is set to `false` no summaries will be displayed.
